### PR TITLE
Fix input text messed up

### DIFF
--- a/static/js/antlr-client.js
+++ b/static/js/antlr-client.js
@@ -46,8 +46,6 @@ function processANTLRResults(response) {
     );
     let newInput = chunks.join('');
 
-    $("#input").html(newInput);
-
     $('#input span').hover(function (event) {
         if ( !event.ctrlKey ) return;
         let oldStyle = $(this).css('text-decoration');


### PR DESCRIPTION
When you enter anything to example code field after run it strips all new lines. That is not necessary. You can chunkily for analysis but there us not need to replace input code.