### PR TITLE
Baseline version of share API.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,11 @@
 	</properties>
 
 	<dependencies>
+		<dependency>
+			<groupId>com.google.cloud</groupId>
+			<artifactId>google-cloud-storage</artifactId>
+			<version>2.13.1</version>
+		</dependency>
         <dependency>
             <groupId>org.antlr</groupId>
             <artifactId>antlr4-runtime</artifactId>

--- a/src/org/antlr/v4/server/persistent/PersistentLayer.java
+++ b/src/org/antlr/v4/server/persistent/PersistentLayer.java
@@ -1,0 +1,23 @@
+package org.antlr.v4.server.persistent;
+
+import java.io.IOException;
+import java.security.InvalidKeyException;
+
+public interface PersistentLayer<K> {
+    /**
+     * Persists a byte buffer in the underlying storage system.
+     * @param buffer byte buffer
+     * @param identifier identifier for the persisted content
+     * @throws IOException captures IO errors
+     */
+    void persist(byte[] buffer, K identifier) throws IOException;
+
+    /**
+     * Retrieves the content from
+     * @param identifier identifier for the persisted content
+     * @return
+     * @throws IOException captures IO errors
+     * @throws InvalidKeyException when key cannot be found
+     */
+    byte[] retrieve(K identifier) throws IOException, InvalidKeyException;
+}

--- a/src/org/antlr/v4/server/persistent/cloudstorage/CloudStoragePersistentLayer.java
+++ b/src/org/antlr/v4/server/persistent/cloudstorage/CloudStoragePersistentLayer.java
@@ -1,0 +1,43 @@
+package org.antlr.v4.server.persistent.cloudstorage;
+
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+import org.antlr.v4.server.ANTLRHttpServer;
+import org.antlr.v4.server.persistent.PersistentLayer;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.security.InvalidKeyException;
+
+public class CloudStoragePersistentLayer implements PersistentLayer<String> {
+    static final ch.qos.logback.classic.Logger LOGGER =
+            (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(ANTLRHttpServer.class);
+
+    public void persist(byte[] byteBuffer, String identifier) throws IOException {
+        for (String key: System.getenv().keySet()) {
+            LOGGER.info(key + " " + System.getenv(key));
+        }
+        // The ID of your GCP project
+        String projectId = "antlr4lab";
+
+        // The ID of your GCS bucket
+        String bucketName = "antlr4-lab-us";
+
+        // The ID of your GCS object
+        String objectName = identifier + ".json";
+
+        // The path to your file to upload
+        Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+        BlobId blobId = BlobId.of(bucketName, objectName);
+        BlobInfo blobInfo = BlobInfo.newBuilder(blobId).build();
+        storage.create(blobInfo, byteBuffer);
+        LOGGER.info("Successfully stored " + objectName);
+    }
+
+    @Override
+    public byte[] retrieve(String identifier) throws IOException, InvalidKeyException {
+        return new byte[0];
+    }
+}

--- a/src/org/antlr/v4/server/unique/DummyUniqueKeyGenerator.java
+++ b/src/org/antlr/v4/server/unique/DummyUniqueKeyGenerator.java
@@ -1,0 +1,11 @@
+package org.antlr.v4.server.unique;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public class DummyUniqueKeyGenerator implements UniqueKeyGenerator {
+    @Override
+    public Optional<String> generateKey() {
+        return Optional.of(UUID.randomUUID().toString());
+    }
+}

--- a/src/org/antlr/v4/server/unique/UniqueKeyGenerator.java
+++ b/src/org/antlr/v4/server/unique/UniqueKeyGenerator.java
@@ -1,0 +1,7 @@
+package org.antlr.v4.server.unique;
+
+import java.util.Optional;
+
+public interface UniqueKeyGenerator {
+    Optional<String> generateKey();
+}


### PR DESCRIPTION
#8 

Adding a "share" API which generates a UUID and stores the page content in CloudStorage.  Will follow up with more changes:
1. frontend change to display a url with the UUID - maybe just directly go to clipboard.
2. recover the content using the url generated by share. 
3. README changes to update instructions on boot the server with correct permissions.
4. ..etc.