### PR TITLE
JsonSerializer: escape error message in tree

### DIFF
--- a/src/org/antlr/v4/server/JsonSerializer.java
+++ b/src/org/antlr/v4/server/JsonSerializer.java
@@ -246,9 +246,9 @@ public class JsonSerializer {
         else if ( t instanceof ErrorNode) {
             Token symbol = ((TerminalNode)t).getSymbol();
             if (symbol != null) {
-                return "{\"error\":\"" + symbol.getText() + "\"}";
+                return "{\"error\":\"" + escapeJSONString(symbol.getText()) + "\"}";
             }
-            return "{\"error\":\""+t.getPayload().toString()+"\"}";
+            return "{\"error\":\"" + escapeJSONString(t.getPayload().toString()) + "\"}";
         }
         else if ( t instanceof TerminalNode) {
             Token symbol = ((TerminalNode)t).getSymbol();


### PR DESCRIPTION
Error messages are injected unescaped in the tree (`result.tree.kids[].error`). If there's a forbidden character, the JSON response becomes invalid. It happens by example if a quoted string is unmatched by the parser

For example:
```json
{
  "result": {
    "tree": {
      "kids": [
        {
          "error": ""string""
        }
      ]
   }
}
```