### PR TITLE
Use Gson to serialize the JSON content

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,11 @@
 			<artifactId>parrtlib</artifactId>
 			<version>0.5-SNAPSHOT</version>
 		</dependency>
+		<dependency>
+			<groupId>com.google.code.gson</groupId>
+			<artifactId>gson</artifactId>
+			<version>2.10</version>
+		</dependency>
 	</dependencies>
 	<build>
 		<sourceDirectory>src</sourceDirectory>

--- a/src/org/antlr/v4/server/CollectGrammarErrorsAndWarnings.java
+++ b/src/org/antlr/v4/server/CollectGrammarErrorsAndWarnings.java
@@ -1,21 +1,19 @@
 package org.antlr.v4.server;
 
-import org.antlr.v4.Tool;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
 import org.antlr.v4.tool.ANTLRMessage;
 import org.antlr.v4.tool.ANTLRToolListener;
 import org.antlr.v4.tool.ErrorManager;
 import org.stringtemplate.v4.ST;
-
-import java.util.ArrayList;
-import java.util.List;
 
 class CollectGrammarErrorsAndWarnings implements ANTLRToolListener {
     ErrorManager errMgr;
 
     String fileName;
 
-    List<String> errors = new ArrayList<>();
-    List<String> warnings = new ArrayList<>();
+    final JsonArray errors = new JsonArray();
+    final JsonArray warnings = new JsonArray();
 
     public CollectGrammarErrorsAndWarnings(ErrorManager errMgr) {
         this.errMgr = errMgr;
@@ -38,13 +36,12 @@ class CollectGrammarErrorsAndWarnings implements ANTLRToolListener {
 
         // Strip "(126)" from "error(126): "
         outputMsg = outputMsg.replaceAll("error\\(.*?\\)", "error");
-        outputMsg = JsonSerializer.escapeJSONString(outputMsg);
-        String s = String.format("{\"type\":\"%s\",\"line\":%d,\"pos\":%d,\"msg\":\"%s\"}",
-                msg.getErrorType().toString(),
-                msg.line,
-                msg.charPosition,
-                outputMsg);
-        errors.add(s);
+        final JsonObject jsonOutput = new JsonObject();
+        jsonOutput.addProperty("type", msg.getErrorType().toString());
+        jsonOutput.addProperty("line", msg.line);
+        jsonOutput.addProperty("pos", msg.charPosition);
+        jsonOutput.addProperty("msg", outputMsg);
+        errors.add(jsonOutput);
     }
 
     @Override
@@ -59,12 +56,11 @@ class CollectGrammarErrorsAndWarnings implements ANTLRToolListener {
         }
 
         outputMsg = outputMsg.replaceAll("warning\\(.*?\\)", "warning");
-        outputMsg = JsonSerializer.escapeJSONString(outputMsg);
-        String s = String.format("{\"type\":\"%s\",\"line\":%d,\"pos\":%d,\"msg\":\"%s\"}",
-                msg.getErrorType().toString(),
-                msg.line,
-                msg.charPosition,
-                outputMsg);
-        warnings.add(s);
+        final JsonObject jsonOutput = new JsonObject();
+        jsonOutput.addProperty("type", msg.getErrorType().toString());
+        jsonOutput.addProperty("line", msg.line);
+        jsonOutput.addProperty("pos", msg.charPosition);
+        jsonOutput.addProperty("msg", outputMsg);
+        errors.add(jsonOutput);
     }
 }

--- a/src/org/antlr/v4/server/CollectLexOrParseSyntaxErrors.java
+++ b/src/org/antlr/v4/server/CollectLexOrParseSyntaxErrors.java
@@ -1,28 +1,29 @@
 package org.antlr.v4.server;
 
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
 import org.antlr.v4.runtime.*;
 
-import java.util.ArrayList;
-import java.util.List;
-
 class CollectLexOrParseSyntaxErrors extends BaseErrorListener {
-    List<String> msgs = new ArrayList<>();
+    final JsonArray msgs = new JsonArray();
 
     @Override
     public void syntaxError(Recognizer<?, ?> recognizer, Object offendingSymbol,
                             int line, int charPositionInLine,
                             String msg,
                             org.antlr.v4.runtime.RecognitionException e) {
-        msg = JsonSerializer.escapeJSONString(msg);
-        String err;
+        final JsonObject err = new JsonObject();
         if ( recognizer instanceof Lexer ) {
             int erridx = ((Lexer) recognizer)._input.index(); // where we detected error
             int startidx = erridx;
             if ( e instanceof LexerNoViableAltException ) {
                 startidx = ((LexerNoViableAltException)e).getStartIndex();
             }
-            err = String.format("{\"startidx\":%d,\"erridx\":%d,\"line\":%d,\"pos\":%d,\"msg\":\"%s\"}",
-                    startidx, erridx, line, charPositionInLine, msg);
+            err.addProperty("startidx", startidx);
+            err.addProperty("erridx", erridx);
+            err.addProperty("line", line);
+            err.addProperty("pos", charPositionInLine);
+            err.addProperty("msg", msg);
         }
         else {
             Token startToken;
@@ -37,8 +38,11 @@ class CollectLexOrParseSyntaxErrors extends BaseErrorListener {
             else {
                 startToken = stopToken = e.getOffendingToken();
             }
-            err = String.format("{\"startidx\":%d,\"stopidx\":%d,\"line\":%d,\"pos\":%d,\"msg\":\"%s\"}",
-                    startToken.getTokenIndex(), stopToken.getTokenIndex(), line, charPositionInLine, msg);
+            err.addProperty("startidx", startToken.getTokenIndex());
+            err.addProperty("stopidx", stopToken.getTokenIndex());
+            err.addProperty("line", line);
+            err.addProperty("pos", charPositionInLine);
+            err.addProperty("msg", msg);
         }
         msgs.add(err);
     }


### PR DESCRIPTION
The third attempt to solve #51 and #54, hopefully better than #57.

It introduces [Gson](https://github.com/google/gson) as a new dependency to serialize the JSON content. `javax.json.JsonReader` is still used to read JSON inputs because it didn't seem broken, but could be migrated as well to the new API if needed.